### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](http://img.shields.io/travis/ikeikeikeike/phoenix_html_simplified_helpers.svg?style=flat-square)](http://travis-ci.org/ikeikeikeike/phoenix_html_simplified_helpers)
 [![Hex version](https://img.shields.io/hexpm/v/phoenix_html_simplified_helpers.svg "Hex version")](https://hex.pm/packages/phoenix_html_simplified_helpers)
 [![Hex downloads](https://img.shields.io/hexpm/dt/phoenix_html_simplified_helpers.svg "Hex downloads")](https://hex.pm/packages/phoenix_html_simplified_helpers)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/ikeikeikeike/phoenix_html_simplified_helpers.svg)](https://beta.hexfaktor.org/github/ikeikeikeike/phoenix_html_simplified_helpers)
 [![Inline docs](https://inch-ci.org/github/ikeikeikeike/phoenix_html_simplified_helpers.svg)](http://inch-ci.org/github/ikeikeikeike/phoenix_html_simplified_helpers)
 [![hex.pm](https://img.shields.io/hexpm/l/ltsv.svg)](https://github.com/ikeikeikeike/phoenix_html_simplified_helpers/blob/master/LICENSE)
 


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/ikeikeikeike/phoenix_html_simplified_helpers.svg)](https://beta.hexfaktor.org/github/ikeikeikeike/phoenix_html_simplified_helpers) [![Inline docs](http://inch-ci.org/github/ikeikeikeike/phoenix_html_simplified_helpers.svg?branch=master)](http://inch-ci.org/github/ikeikeikeike/phoenix_html_simplified_helpers)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!
