### PR TITLE
Fix Elixir 1.3 warnings

### DIFF
--- a/lib/phoenix_html_simplified_helpers/time_ago_in_words.ex
+++ b/lib/phoenix_html_simplified_helpers/time_ago_in_words.ex
@@ -33,10 +33,7 @@ defmodule Phoenix.HTML.SimplifiedHelpers.TimeAgoInWords do
 
   @spec distance_of_time_in_words(Integer.t, Integer.t) :: String.t
   def distance_of_time_in_words(from_time, to_time) when is_integer(from_time) and is_integer(to_time) do
-    if from_time > to_time do
-      from_time = to_time
-      to_time = from_time
-    end
+    from_time = Enum.min([from_time, to_time])
 
     distance_in_minutes = round((to_time - from_time) / 60.0)
     distance_in_seconds = round(to_time - from_time)


### PR DESCRIPTION
I'm seeing a whole heap of warnings when using this library with Elixir 1.3, I've popped a sample of one below.

```
warning: the variable "from_time" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/phoenix_html_simplified_helpers/time_ago_in_words.ex:42
```

I've replaced the `if` statement with a call to `Enum.min`, which I think will achieve the same effect as before and seems to get rid of the warning. The tests still pass for me as well.

I'm very new to Elixir so please let me know if you know of a better way. Also, thanks for your work on this library!
