### PR TITLE
fixes deprecation on Enum.chunk

### DIFF
--- a/lib/phoenix_html_simplified_helpers/number_with_delimiter.ex
+++ b/lib/phoenix_html_simplified_helpers/number_with_delimiter.ex
@@ -5,7 +5,7 @@ defmodule Phoenix.HTML.SimplifiedHelpers.NumberWithDelimiter do
     i
     |> Integer.to_charlist()
     |> Enum.reverse()
-    |> Enum.chunk(3, 3, [])
+    |> Enum.chunk_every(3, 3, [])
     |> Enum.join(",")
     |> String.reverse()
   end


### PR DESCRIPTION
Hello! This PR fixes the deprection on `Enum.chunk/4`, which is now replaced by `Enum.chunk_every/4`.

Fixes https://github.com/ikeikeikeike/phoenix_html_simplified_helpers/issues/14